### PR TITLE
fix: try to get it working

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -8,5 +8,8 @@
       "@@/*": ["./*"]
     }
   },
-  "exclude": ["node_modules", ".nuxt", "dist"]
+  "exclude": ["node_modules", ".nuxt", "dist"],
+  "vueCompilerOptions": {
+    "target": 2.7
+  }
 }

--- a/pages/vote/_id/index.vue
+++ b/pages/vote/_id/index.vue
@@ -19,7 +19,7 @@
 <script>
 import { mapGetters } from 'vuex';
 import web3 from 'web3';
-import { MerkleTree } from '~/helper/merkleTree';
+import { MerkleTree } from '~/helper/merkletree';
 import { voters } from '~/constant/stub'
 import { DEPOSIT_VALUE } from '~/constant';
 import { getEVotingContract } from '~/contracts'


### PR DESCRIPTION
After these changes, I still have problem running on MacOS (okay on Linux). There is an error

```
client.js?06a0:103 Error: This method only supports Buffer but input was: (some hex string)
```

Is this problem similar to that in the main repo? Do we need to run it in a container?
